### PR TITLE
Fix ~1.16.1 lootable & Jitpack issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,3 +36,11 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+}

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+jdk:
+  - openjdk17
+before_install:
+  - sdk install java 17.0.1-open
+  - sdk use java 17.0.1-open

--- a/src/main/java/Xinyuiii/properties/BastionGenerator.java
+++ b/src/main/java/Xinyuiii/properties/BastionGenerator.java
@@ -107,7 +107,7 @@ public class BastionGenerator {
             if (version.isBetween(MCVersion.v1_16,MCVersion.v1_16_1)) {
                 tables = BastionStructureLoot.STRUCTURE_LOOT_1_16_0.get(p.name);
             }
-            if (version.isBetween(MCVersion.v1_16_2,MCVersion.v1_19_4)) {
+            else if (version.isBetween(MCVersion.v1_16_2,MCVersion.v1_19_4)) {
                 tables = BastionStructureLoot.STRUCTURE_LOOT_1_16_2.get(p.name);
             }
             else {


### PR DESCRIPTION
- Changed jitpack build java version to openjdk-17 for compatibility with `VillageGenerator`
- Added `publishing` stuff in `build.gradle` for output stuffs in jitpack
- Fix 1.16/1.16.1 lootable has broken cause by missing `else` block